### PR TITLE
Publish test results no block

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,9 +5,10 @@
 
 trigger:
 - master
+- publish-test-results-no-block
 
 # no PR builds on this file
-pr: none
+#pr: none
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -31,9 +32,27 @@ steps:
       npm run test
     displayName: 'Unit test'
 
+  - task: PublishTestResults@2
+    displayName: Publish unit test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: '$(System.DefaultWorkingDirectory)/unit-test-report.xml'
+      testRunTitle: Unit test results
+      failTaskOnFailedTests: false
+    condition: succeededOrFailed()
+
   - script: |
       npm run test:integration
     displayName: 'Integration test'
+
+  - task: PublishTestResults@2
+    displayName: Publish integration test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: '$(System.DefaultWorkingDirectory)/integration-test-report.xml'
+      testRunTitle: Integration test results
+      failTaskOnFailedTests: false
+    condition: succeededOrFailed()
 
   - task: DockerInstaller@0
     inputs:
@@ -48,11 +67,11 @@ steps:
       dockerComposeFile: '**/docker-compose.yml'
       action: 'Build services'
 
-  - task: DockerCompose@0
-    displayName: 'Docker Push: gpitfuturesdevacr'
-    inputs:
-      containerregistrytype: 'Azure Container Registry'
-      azureSubscription: 'NHSAPP-BuyingCatalogue'
-      azureContainerRegistry: '{"loginServer":"gpitfuturesdevacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-dev-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesdevacr"}'
-      dockerComposeFile: '**/docker-compose.yml'
-      action: 'Push services'
+#  - task: DockerCompose@0
+#    displayName: 'Docker Push: gpitfuturesdevacr'
+#    inputs:
+#      containerregistrytype: 'Azure Container Registry'
+#      azureSubscription: 'NHSAPP-BuyingCatalogue'
+#      azureContainerRegistry: '{"loginServer":"gpitfuturesdevacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-dev-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesdevacr"}'
+#      dockerComposeFile: '**/docker-compose.yml'
+#      action: 'Push services'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,10 +5,9 @@
 
 trigger:
 - master
-- publish-test-results-no-block
 
 # no PR builds on this file
-#pr: none
+pr: none
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -67,11 +66,11 @@ steps:
       dockerComposeFile: '**/docker-compose.yml'
       action: 'Build services'
 
-#  - task: DockerCompose@0
-#    displayName: 'Docker Push: gpitfuturesdevacr'
-#    inputs:
-#      containerregistrytype: 'Azure Container Registry'
-#      azureSubscription: 'NHSAPP-BuyingCatalogue'
-#      azureContainerRegistry: '{"loginServer":"gpitfuturesdevacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-dev-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesdevacr"}'
-#      dockerComposeFile: '**/docker-compose.yml'
-#      action: 'Push services'
+  - task: DockerCompose@0
+    displayName: 'Docker Push: gpitfuturesdevacr'
+    inputs:
+      containerregistrytype: 'Azure Container Registry'
+      azureSubscription: 'NHSAPP-BuyingCatalogue'
+      azureContainerRegistry: '{"loginServer":"gpitfuturesdevacr.azurecr.io", "id" : "/subscriptions/7b12a8a2-f06f-456f-b6f9-aa2d92e0b2ec/resourceGroups/gpitfutures-dev-rg-acr/providers/Microsoft.ContainerRegistry/registries/gpitfuturesdevacr"}'
+      dockerComposeFile: '**/docker-compose.yml'
+      action: 'Push services'


### PR DESCRIPTION
I've readded the task to publish the test results, but set it to not block the pipeline if there are failures
When we have more confident in the pipeline and want to be strict about failing tests it's just an easy change from false to true in two places

Example of report can be seen here:
https://buyingcatalog.visualstudio.com/Buying%20Catalogue/_build/results?buildId=1903&view=ms.vss-test-web.build-test-results-tab