### PR TITLE
Refactor transformer

### DIFF
--- a/app/section/controller.js
+++ b/app/section/controller.js
@@ -42,7 +42,7 @@ export const postSection = async ({
   solutionId, sectionId, sectionData, dashboardId,
 }) => {
   const sectionManifest = new ManifestProvider().getSectionManifest({ dashboardId, sectionId });
-  const transformedSectionData = transformSectionData({ sectionId, sectionManifest, sectionData });
+  const transformedSectionData = transformSectionData({ sectionManifest, sectionData });
   try {
     const endpoint = `${apiHost}/api/v1/Solutions/${solutionId}/sections/${sectionId}`;
     logger.info(`api called: [PUT] ${endpoint}`);

--- a/app/section/helpers/transformSectionData.js
+++ b/app/section/helpers/transformSectionData.js
@@ -11,45 +11,23 @@ const arrayTransformation = (questionValue) => {
 };
 
 const transformationStratergy = {
-  'client-application-types': {
-    'client-application-types': {
-      transform: questionValue => arrayTransformation(questionValue),
-    },
-  },
-  'browser-browsers-supported': {
-    'supported-browsers': {
-      transform: questionValue => arrayTransformation(questionValue),
-    },
-  },
-  'native-mobile-operating-systems': {
-    'operating-systems': {
-      transform: questionValue => arrayTransformation(questionValue),
-    },
-  },
-  'native-mobile-connection-details': {
-    'connection-types': {
-      transform: questionValue => arrayTransformation(questionValue),
-    },
+  'checkbox-options': {
+    transform: questionValue => arrayTransformation(questionValue),
   },
 };
 
 export const transformSectionData = ({
-  sectionId, sectionManifest, sectionData,
-}) => {
-  if (transformationStratergy[sectionId]) {
-    const transformedSectionData = {};
-
-    Object.keys(sectionManifest.questions).map((questionId) => {
-      if (transformationStratergy[sectionId][questionId]) {
-        const transformedQuestionValue = transformationStratergy[sectionId][questionId]
-          .transform(sectionData[questionId]);
-        transformedSectionData[questionId] = transformedQuestionValue;
-      } else {
-        transformedSectionData[questionId] = sectionData[questionId];
-      }
+  sectionManifest, sectionData,
+}) => Object.entries(sectionManifest.questions)
+  .reduce((transformedSectionData, [questionId, questionManifest]) => {
+    if (transformationStratergy[questionManifest.type]) {
+      return ({
+        ...transformedSectionData,
+        [questionId]: transformationStratergy[questionManifest.type]
+          .transform(sectionData[questionId]),
+      });
+    }
+    return ({
+      ...transformedSectionData,
     });
-
-    return transformedSectionData;
-  }
-  return sectionData;
-};
+  }, { ...sectionData });

--- a/app/section/helpers/transformSectionData.test.js
+++ b/app/section/helpers/transformSectionData.test.js
@@ -1,74 +1,138 @@
 import { transformSectionData } from './transformSectionData';
 
 describe('transformSectionData', () => {
-  it('should return the sectionData provided as is if no strategy for the section has been defined', () => {
+  it('should return the sectionData provided as is if the question does not exist in the manifest', () => {
     const sectionData = {
-      'some-question-id': 'Some data',
-    };
-
-    const sectionManifest = {};
-
-    const transformedSectionData = transformSectionData({ sectionId: 'some-section-id', sectionManifest, sectionData });
-
-    expect(transformedSectionData).toEqual(sectionData);
-  });
-
-  it('should return the sectionData provided as is if no strategy for the question has been defined', () => {
-    const sectionData = {
-      'some-question-id': 'Some data',
+      'some-question-id-1': 'Some data',
+      'some-question-id-2': 'Some data',
     };
 
     const sectionManifest = {
       questions: {
-        'some-question-id': {},
-        'some-other-question-id': {},
+        'some-other-question-id': {
+        },
       },
     };
 
-    const transformedSectionData = transformSectionData({ sectionId: 'client-application-types', sectionManifest, sectionData });
+    const transformedSectionData = transformSectionData({ sectionManifest, sectionData });
 
     expect(transformedSectionData).toEqual(sectionData);
   });
 
-  describe('when a transformation stratergy does exist for the section and question', () => {
+  it('should return the sectionData provided as is if the question does exist but there is no transform strategy for the question type', () => {
+    const sectionData = {
+      'some-question-id-1': 'Some data',
+      'some-question-id-2': 'Some data',
+    };
+
     const sectionManifest = {
       questions: {
-        'client-application-types': {},
+        'some-question-id-1': {
+          type: 'some-type',
+        },
       },
     };
 
+    const transformedSectionData = transformSectionData({ sectionManifest, sectionData });
+
+    expect(transformedSectionData).toEqual(sectionData);
+  });
+
+  describe('when a transformation stratergy does exist for the question', () => {
     it('should return the sectionData provided as is if the sectionData is an array of strings', () => {
       const sectionData = {
-        'client-application-types': ['some first value', 'some second value'],
+        'some-question-id-1': ['some first value', 'some second value'],
       };
 
-      const transformedSectionData = transformSectionData({ sectionId: 'client-application-types', sectionManifest, sectionData });
+      const sectionManifest = {
+        questions: {
+          'some-question-id-1': {
+            type: 'checkbox-options',
+          },
+        },
+      };
+
+      const transformedSectionData = transformSectionData({ sectionManifest, sectionData });
 
       expect(transformedSectionData).toEqual(sectionData);
     });
 
     it('should return the transformed sectionData as an array string of one when the section data is just a string', () => {
       const expectedTransformedSectionData = {
-        'client-application-types': ['some first value'],
+        'some-question-id-1': ['some first value'],
       };
 
       const sectionData = {
-        'client-application-types': 'some first value',
+        'some-question-id-1': 'some first value',
       };
 
-      const transformedSectionData = transformSectionData({ sectionId: 'client-application-types', sectionManifest, sectionData });
+      const sectionManifest = {
+        questions: {
+          'some-question-id-1': {
+            type: 'checkbox-options',
+          },
+        },
+      };
+
+      const transformedSectionData = transformSectionData({ sectionManifest, sectionData });
 
       expect(transformedSectionData).toEqual(expectedTransformedSectionData);
     });
 
     it('should return the transformed sectionData of the question as an empty array', () => {
       const expectedTransformedSectionData = {
-        'client-application-types': [],
+        'some-question-id-1': [],
       };
 
       const sectionData = {};
 
-      const transformedSectionData = transformSectionData({ sectionId: 'client-application-types', sectionManifest, sectionData });
+      const sectionManifest = {
+        questions: {
+          'some-question-id-1': {
+            type: 'checkbox-options',
+          },
+        },
+      };
+
+      const transformedSectionData = transformSectionData({ sectionManifest, sectionData });
+
+      expect(transformedSectionData).toEqual(expectedTransformedSectionData);
+    });
+
+    it('should return the transformed sectionData for a mixture of questions to transform', () => {
+      const expectedTransformedSectionData = {
+        'some-question-id-1': [],
+        'some-question-id-2': ['one-value'],
+        'some-question-id-3': '',
+        'some-question-id-4': ['first-value', 'second-value'],
+        'some-question-id-5': 'some-simple-value',
+      };
+
+      const sectionData = {
+        'some-question-id-2': 'one-value',
+        'some-question-id-3': '',
+        'some-question-id-4': ['first-value', 'second-value'],
+        'some-question-id-5': 'some-simple-value',
+      };
+
+      const sectionManifest = {
+        questions: {
+          'some-question-id-1': {
+            type: 'checkbox-options',
+          },
+          'some-question-id-2': {
+            type: 'checkbox-options',
+          },
+          'some-question-id-4': {
+            type: 'checkbox-options',
+          },
+          'some-question-id-5': {
+            type: 'text-field',
+          },
+        },
+      };
+
+      const transformedSectionData = transformSectionData({ sectionManifest, sectionData });
 
       expect(transformedSectionData).toEqual(expectedTransformedSectionData);
     });


### PR DESCRIPTION
The transformation was using the sectionId and questionId to determine if the data to be sent to the api needed transforming. As a result when a new question or section that needed transforming or when it was renamed. The transformer also needed updating. 

This has now changed to be more flexible and base the transformation on the questionType. Since only questions that are of type checkbox-options are the ones that were needed to be updated.