### PR TITLE
added dependsOn so that jobs run sequentially instead of parallel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,7 @@ jobs:
 - job: dockerBuildAndPush
   displayName: Build and push docker containers to the acr
   condition: and(succeeded(), not(eq(variables['build.reason'], 'PullRequest')))
+  dependsOn: buildAndTest
   steps:
   - task: DockerInstaller@0
     inputs:


### PR DESCRIPTION
I read somewhere that stages by default continue to run sequentially, I thought the same would be true of jobs. Turns out i was wrong. Jobs run in parallel, which meant the docker publish was complete before we had finished running the integration tests on the merged master branch.
This change will force it to wait.