### PR TITLE
4314 extract api calls

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    ["@babel/env"]
+    ["@babel/preset-env", { "targets": { "node": "current" } }]
   ]
 }

--- a/app/apiProvider.js
+++ b/app/apiProvider.js
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import { apiHost } from './config';
+import logger from './logger';
+
+export class ApiProvider {
+  constructor() {
+    this.apiHost = apiHost;
+  }
+
+  async getSectionData({ solutionId, sectionId }) {
+    const endpoint = `${this.apiHost}/api/v1/Solutions/${solutionId}/sections/${sectionId}`;
+    logger.info(`api called: [GET] ${endpoint}`);
+
+    return axios.get(endpoint);
+  }
+
+  async putSectionData({ solutionId, sectionId, sectionData }) {
+    const endpoint = `${this.apiHost}/api/v1/Solutions/${solutionId}/sections/${sectionId}`;
+    logger.info(`api called: [PUT] ${endpoint}: ${JSON.stringify(sectionData)}`);
+
+    await axios.put(endpoint, sectionData);
+
+    return true;
+  }
+}

--- a/app/apiProvider.js
+++ b/app/apiProvider.js
@@ -22,4 +22,10 @@ export class ApiProvider {
 
     return true;
   }
+
+  async getMainDashboardData({ solutionId }) {
+    const endpoint = `${this.apiHost}/api/v1/Solutions/${solutionId}/dashboard`;
+    logger.info(`api called: [GET] ${endpoint}`);
+    return axios.get(endpoint);
+  }
 }

--- a/app/apiProvider.js
+++ b/app/apiProvider.js
@@ -26,6 +26,14 @@ export class ApiProvider {
   async getMainDashboardData({ solutionId }) {
     const endpoint = `${this.apiHost}/api/v1/Solutions/${solutionId}/dashboard`;
     logger.info(`api called: [GET] ${endpoint}`);
+
+    return axios.get(endpoint);
+  }
+
+  async getSubDashboardData({ solutionId, dashboardId }) {
+    const endpoint = `${this.apiHost}/api/v1/Solutions/${solutionId}/dashboards/${dashboardId}`;
+    logger.info(`api called: [GET] ${endpoint}`);
+
     return axios.get(endpoint);
   }
 

--- a/app/apiProvider.js
+++ b/app/apiProvider.js
@@ -28,4 +28,12 @@ export class ApiProvider {
     logger.info(`api called: [GET] ${endpoint}`);
     return axios.get(endpoint);
   }
+
+  async putSubmitForModeration({ solutionId }) {
+    const endpoint = `${this.apiHost}/api/v1/Solutions/${solutionId}/SubmitForReview`;
+    logger.info(`api called: [PUT] ${endpoint}`);
+    await axios.put(endpoint, {});
+
+    return true;
+  }
 }

--- a/app/apiProvider.js
+++ b/app/apiProvider.js
@@ -37,6 +37,13 @@ export class ApiProvider {
     return axios.get(endpoint);
   }
 
+  async getPreviewData({ solutionId }) {
+    const endpoint = `${this.apiHost}/api/v1/Solutions/${solutionId}/preview`;
+    logger.info(`api called: [GET] ${endpoint}`);
+
+    return axios.get(endpoint);
+  }
+
   async putSubmitForModeration({ solutionId }) {
     const endpoint = `${this.apiHost}/api/v1/Solutions/${solutionId}/SubmitForReview`;
     logger.info(`api called: [PUT] ${endpoint}`);

--- a/app/pages/dashboard/controller.js
+++ b/app/pages/dashboard/controller.js
@@ -26,7 +26,6 @@ export const postSubmitForModeration = async ({ solutionId }) => {
       success: true,
     };
   } catch (error) {
-    console.log(`error: ${JSON.stringify(error)}`)
     return error.response.data;
   }
 };

--- a/app/pages/dashboard/controller.js
+++ b/app/pages/dashboard/controller.js
@@ -24,9 +24,7 @@ export const getMarketingPageDashboardContext = async ({ solutionId, validationE
 
 export const postSubmitForModeration = async ({ solutionId }) => {
   try {
-    const endpoint = `${apiHost}/api/v1/Solutions/${solutionId}/SubmitForReview`;
-    logger.info(`api called: [PUT] ${endpoint}`);
-    await axios.put(endpoint, {});
+    await new ApiProvider().putSubmitForModeration({ solutionId });
     return {
       success: true,
     };

--- a/app/pages/dashboard/controller.js
+++ b/app/pages/dashboard/controller.js
@@ -26,6 +26,7 @@ export const postSubmitForModeration = async ({ solutionId }) => {
       success: true,
     };
   } catch (error) {
+    console.log(`error: ${JSON.stringify(error)}`)
     return error.response.data;
   }
 };

--- a/app/pages/dashboard/controller.js
+++ b/app/pages/dashboard/controller.js
@@ -1,15 +1,14 @@
 import axios from 'axios';
 import { ManifestProvider } from '../../manifestProvider';
+import { ApiProvider } from '../../apiProvider';
 import { createDashboardPageContext } from './createDashboardPageContext';
 import { apiHost } from '../../config';
 import logger from '../../logger';
 
 export const getMarketingPageDashboardContext = async ({ solutionId, validationErrors }) => {
   const dashboardManifest = new ManifestProvider().getDashboardManifest();
+  const dashboardDataRaw = await new ApiProvider().getMainDashboardData({ solutionId });
 
-  const endpoint = `${apiHost}/api/v1/Solutions/${solutionId}/dashboard`;
-  logger.info(`api called: [GET] ${endpoint}`);
-  const dashboardDataRaw = await axios.get(endpoint);
   if (dashboardDataRaw && dashboardDataRaw.data) {
     const dashboardData = dashboardDataRaw.data;
     const context = createDashboardPageContext({

--- a/app/pages/dashboard/controller.js
+++ b/app/pages/dashboard/controller.js
@@ -1,9 +1,6 @@
-import axios from 'axios';
 import { ManifestProvider } from '../../manifestProvider';
 import { ApiProvider } from '../../apiProvider';
 import { createDashboardPageContext } from './createDashboardPageContext';
-import { apiHost } from '../../config';
-import logger from '../../logger';
 
 export const getMarketingPageDashboardContext = async ({ solutionId, validationErrors }) => {
   const dashboardManifest = new ManifestProvider().getDashboardManifest();

--- a/app/pages/dashboard/controller.test.js
+++ b/app/pages/dashboard/controller.test.js
@@ -1,0 +1,108 @@
+import { getMarketingPageDashboardContext, postSubmitForModeration } from './controller';
+import { ManifestProvider } from '../../manifestProvider';
+import { ApiProvider } from '../../apiProvider';
+
+jest.mock('../../manifestProvider');
+jest.mock('../../apiProvider');
+
+describe('dashboard controller', () => {
+  describe('getMarketingPageDashboardContext', () => {
+    const dashboardManifest = {
+      sectionGroups: {
+        'some-section-group-id': {
+          title: 'Some section group',
+          sections: {
+            'some-section-id': {
+              title: 'Some section',
+              type: 'section',
+            },
+          },
+        },
+      },
+    };
+
+    const dashboardData = {
+      data: {
+        sections: {
+          'some-section-id': {
+            status: 'INCOMPLETE',
+            requirement: 'Mandatory',
+          },
+        },
+      },
+    };
+
+    it('should return the context when the manifest and data from the api is provided', async () => {
+      const expectedContext = {
+        previewUrl: '/solution/some-solution-id/preview',
+        submitForModerationUrl: '/solution/some-solution-id/submitForModeration',
+        returnToDashboardUrl: '/solution/some-solution-id',
+        sectionGroups: [
+          {
+            id: 'some-section-group-id',
+            title: 'Some section group',
+            sections: [
+              {
+                URL: '/solution/some-solution-id/section/some-section-id',
+                id: 'some-section-id',
+                title: 'Some section',
+                requirement: 'Mandatory',
+                status: 'INCOMPLETE',
+                isActive: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      ManifestProvider.prototype.getDashboardManifest.mockReturnValue(dashboardManifest);
+      ApiProvider.prototype.getMainDashboardData.mockResolvedValue(dashboardData);
+
+      const context = await getMarketingPageDashboardContext({ solutionId: 'some-solution-id', dashboardId: 'some-dashboard-id' });
+
+      expect(context).toEqual(expectedContext);
+    });
+
+    it('should throw an error when no data is returned from the ApiProvider', async () => {
+      ManifestProvider.prototype.getDashboardManifest.mockReturnValue(dashboardManifest);
+      ApiProvider.prototype.getMainDashboardData.mockResolvedValue({});
+
+      try {
+        await getMarketingPageDashboardContext({ solutionId: 'some-solution-id', dashboardId: 'some-dashboard-id' });
+      } catch (err) {
+        expect(err).toEqual(new Error('No data returned'));
+      }
+    });
+  });
+
+  describe('postSubmitForModeration', () => {
+    it('should return a response indicating the submit for moderation was successful', async () => {
+      const expectedResponse = {
+        success: true,
+      };
+
+      ApiProvider.prototype.putSubmitForModeration.mockResolvedValue(true);
+
+      const response = await postSubmitForModeration({ solutionId: 'some-solution-id' });
+
+      expect(response).toEqual(expectedResponse);
+    });
+
+    it('should return the details of the error thrown by the ApiProvider', async () => {
+      const errorResponse = {
+        response: {
+          data: {
+            message: 'something important',
+          },
+        },
+      };
+
+      ApiProvider.prototype.putSubmitForModeration.mockImplementation(
+        () => Promise.reject(errorResponse),
+      );
+
+      const response = await postSubmitForModeration({ solutionId: 'some-solution-id' });
+      expect(response).toEqual(errorResponse.response.data);
+    });
+  });
+});

--- a/app/pages/dashboard/subDashboards/controller.js
+++ b/app/pages/dashboard/subDashboards/controller.js
@@ -1,15 +1,11 @@
-import axios from 'axios';
 import { ManifestProvider } from '../../../manifestProvider';
+import { ApiProvider } from '../../../apiProvider';
 import { createDashboardPageContext } from '../createDashboardPageContext';
-import logger from '../../../logger';
-import { apiHost } from '../../../config';
 
 export const getSubDashboardPageContext = async ({ solutionId, dashboardId }) => {
   const dashboardManifest = new ManifestProvider().getSubDashboardManifest({ dashboardId });
+  const sectionData = await new ApiProvider().getSubDashboardData({ solutionId, dashboardId });
 
-  const endpoint = `${apiHost}/api/v1/Solutions/${solutionId}/dashboards/${dashboardId}`;
-  logger.info(`api called: [GET] ${endpoint}`);
-  const sectionData = await axios.get(endpoint);
   if (sectionData && sectionData.data) {
     const { sections } = sectionData.data;
     const context = createDashboardPageContext({

--- a/app/pages/dashboard/subDashboards/controller.test.js
+++ b/app/pages/dashboard/subDashboards/controller.test.js
@@ -6,7 +6,7 @@ jest.mock('../../../manifestProvider');
 jest.mock('../../../apiProvider');
 
 describe('subDashboards controller', () => {
-  const dashboardManifest = {
+  const subDashboardManifest = {
     sectionGroups: {
       'some-section-group-id': {
         title: 'Some section group',
@@ -20,7 +20,7 @@ describe('subDashboards controller', () => {
     },
   };
 
-  const marketingDataSections = {
+  const subDashboardData = {
     data: {
       sections: {
         'some-section-id': {
@@ -54,8 +54,8 @@ describe('subDashboards controller', () => {
       ],
     };
 
-    ManifestProvider.prototype.getSubDashboardManifest.mockReturnValue(dashboardManifest);
-    ApiProvider.prototype.getSubDashboardData.mockResolvedValue(marketingDataSections);
+    ManifestProvider.prototype.getSubDashboardManifest.mockReturnValue(subDashboardManifest);
+    ApiProvider.prototype.getSubDashboardData.mockResolvedValue(subDashboardData);
 
     const context = await getSubDashboardPageContext({ solutionId: 'some-solution-id', dashboardId: 'some-dashboard-id' });
 
@@ -63,7 +63,7 @@ describe('subDashboards controller', () => {
   });
 
   it('should throw an error when no data is returned from the ApiProvider', async () => {
-    ManifestProvider.prototype.getSubDashboardManifest.mockReturnValue(dashboardManifest);
+    ManifestProvider.prototype.getSubDashboardManifest.mockReturnValue(subDashboardManifest);
     ApiProvider.prototype.getSubDashboardData.mockResolvedValue({});
 
     try {

--- a/app/pages/dashboard/subDashboards/controller.test.js
+++ b/app/pages/dashboard/subDashboards/controller.test.js
@@ -1,0 +1,65 @@
+import { getSubDashboardPageContext } from './controller';
+import { ManifestProvider } from '../../../manifestProvider';
+import { ApiProvider } from '../../../apiProvider';
+
+jest.mock('../../../manifestProvider');
+jest.mock('../../../apiProvider');
+
+describe('subDashboards controller', () => {
+  const dashboardManifest = {
+    sectionGroups: {
+      'some-section-group-id': {
+        title: 'Some section group',
+        sections: {
+          'some-section-id': {
+            title: 'Some section',
+            type: 'section',
+          },
+        },
+      },
+    },
+  };
+
+  const marketingDataSections = {
+    data: {
+      sections: {
+        'some-section-id': {
+          status: 'INCOMPLETE',
+          requirement: 'Mandatory',
+        },
+      },
+    },
+  };
+
+  it('should return the context when the manifest and data from the api is provided', async () => {
+    const expectedContext = {
+      previewUrl: '/solution/some-solution-id/preview',
+      submitForModerationUrl: '/solution/some-solution-id/submitForModeration',
+      returnToDashboardUrl: '/solution/some-solution-id',
+      sectionGroups: [
+        {
+          id: 'some-section-group-id',
+          title: 'Some section group',
+          sections: [
+            {
+              URL: '/solution/some-solution-id/dashboard/some-dashboard-id/section/some-section-id',
+              id: 'some-section-id',
+              title: 'Some section',
+              requirement: 'Mandatory',
+              status: 'INCOMPLETE',
+              isActive: true,
+            },
+          ],
+        },
+      ],
+    };
+
+    ManifestProvider.prototype.getSubDashboardManifest.mockReturnValue(dashboardManifest);
+
+    ApiProvider.prototype.getSubDashboardData.mockResolvedValue(marketingDataSections);
+
+    const context = await getSubDashboardPageContext({ solutionId: 'some-solution-id', dashboardId: 'some-dashboard-id' });
+
+    expect(context).toEqual(expectedContext);
+  });
+});

--- a/app/pages/dashboard/subDashboards/controller.test.js
+++ b/app/pages/dashboard/subDashboards/controller.test.js
@@ -55,11 +55,21 @@ describe('subDashboards controller', () => {
     };
 
     ManifestProvider.prototype.getSubDashboardManifest.mockReturnValue(dashboardManifest);
-
     ApiProvider.prototype.getSubDashboardData.mockResolvedValue(marketingDataSections);
 
     const context = await getSubDashboardPageContext({ solutionId: 'some-solution-id', dashboardId: 'some-dashboard-id' });
 
     expect(context).toEqual(expectedContext);
+  });
+
+  it('should throw an error when no data is returned from the ApiProvider', async () => {
+    ManifestProvider.prototype.getSubDashboardManifest.mockReturnValue(dashboardManifest);
+    ApiProvider.prototype.getSubDashboardData.mockResolvedValue({});
+
+    try {
+      await getSubDashboardPageContext({ solutionId: 'some-solution-id', dashboardId: 'some-dashboard-id' });
+    } catch (err) {
+      expect(err).toEqual(new Error('No data returned'));
+    }
   });
 });

--- a/app/pages/preview/controller.js
+++ b/app/pages/preview/controller.js
@@ -1,12 +1,9 @@
-import axios from 'axios';
+import { ApiProvider } from '../../apiProvider';
 import { createPreviewPageContext } from './createPreviewPageContext';
-import { apiHost } from '../../config';
-import logger from '../../logger';
 
 export const getPreviewPageContext = async ({ solutionId }) => {
-  const endpoint = `${apiHost}/api/v1/Solutions/${solutionId}/preview`;
-  logger.info(`api called: [GET] ${endpoint}`);
-  const previewDataRaw = await axios.get(endpoint);
+  const previewDataRaw = await new ApiProvider().getPreviewData({ solutionId });
+
   if (previewDataRaw && previewDataRaw.data) {
     const previewData = previewDataRaw.data;
     const context = createPreviewPageContext({ previewData });

--- a/app/pages/preview/controller.test.js
+++ b/app/pages/preview/controller.test.js
@@ -1,0 +1,43 @@
+import { getPreviewPageContext } from './controller';
+import { ApiProvider } from '../../apiProvider';
+
+jest.mock('../../apiProvider');
+
+describe('preview controller', () => {
+  const previewData = {
+    data: {
+      id: 'some-solution',
+      sections: {
+        'some-section': {
+          answers: {},
+        },
+      },
+    },
+  };
+
+  it('should return the context when preview data is returned by the ApiProvider', async () => {
+    const expectedContext = {
+      sections: {
+        'some-section': {
+          answers: {},
+        },
+      },
+    };
+
+    ApiProvider.prototype.getPreviewData.mockResolvedValue(previewData);
+
+    const context = await getPreviewPageContext({ solutionId: 'some-solution-id' });
+
+    expect(context).toEqual(expectedContext);
+  });
+
+  it('should throw an error when no data is returned from the ApiProvider', async () => {
+    ApiProvider.prototype.getPreviewData.mockResolvedValue({});
+
+    try {
+      await getPreviewPageContext({ solutionId: 'some-solution-id' });
+    } catch (err) {
+      expect(err).toEqual(new Error('No data returned'));
+    }
+  });
+});

--- a/app/pages/section/controller.js
+++ b/app/pages/section/controller.js
@@ -1,10 +1,8 @@
-import axios from 'axios';
 import { ManifestProvider } from '../../manifestProvider';
 import { ApiProvider } from '../../apiProvider';
 import { createSectionPageContext } from './createSectionPageContext';
 import { transformSectionData } from './helpers/transformSectionData';
 import { createPostSectionResponse } from './helpers/createPostSectionResponse';
-import { apiHost } from '../../config';
 import logger from '../../logger';
 
 export const getSectionPageContext = async ({

--- a/app/pages/section/controller.js
+++ b/app/pages/section/controller.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { ManifestProvider } from '../../manifestProvider';
+import { ApiProvider } from '../../apiProvider';
 import { createSectionPageContext } from './createSectionPageContext';
 import { transformSectionData } from './helpers/transformSectionData';
 import { createPostSectionResponse } from './helpers/createPostSectionResponse';
@@ -13,10 +14,8 @@ export const getSectionPageContext = async ({
     dashboardId,
     sectionId,
   });
-  const endpoint = `${apiHost}/api/v1/Solutions/${solutionId}/sections/${sectionId}`;
-  logger.info(`api called: [GET] ${endpoint}`);
-  const sectionData = await axios.get(endpoint);
-  if (sectionData && sectionData) {
+  const sectionData = await new ApiProvider().getSectionData({ solutionId, sectionId });
+  if (sectionData && sectionData.data) {
     const formData = sectionData.data;
     const context = createSectionPageContext({
       solutionId, sectionManifest, formData, dashboardId,
@@ -44,11 +43,9 @@ export const postSection = async ({
   const sectionManifest = new ManifestProvider().getSectionManifest({ dashboardId, sectionId });
   const transformedSectionData = transformSectionData({ sectionManifest, sectionData });
   try {
-    const endpoint = `${apiHost}/api/v1/Solutions/${solutionId}/sections/${sectionId}`;
-
-    logger.info(`api called: [PUT] ${endpoint}: ${JSON.stringify(transformedSectionData)}`);
-
-    await axios.put(endpoint, transformedSectionData);
+    await new ApiProvider().putSectionData({
+      solutionId, sectionId, sectionData: transformedSectionData,
+    });
 
     const response = createPostSectionResponse({ solutionId, sectionManifest });
 

--- a/app/pages/section/controller.test.js
+++ b/app/pages/section/controller.test.js
@@ -1,0 +1,67 @@
+import { getSectionPageContext } from './controller';
+import { ManifestProvider } from '../../manifestProvider';
+import { ApiProvider } from '../../apiProvider';
+
+jest.mock('../../manifestProvider');
+jest.mock('../../apiProvider');
+
+describe('section controller', () => {
+  describe('getSectionPageContext', () => {
+    const sectionManifest = {
+      id: 'some-section-id',
+      title: 'Some section title',
+      mainAdvice: 'Some main advice.',
+      additionalAdvice: [
+        'Some first bit of additional advice.',
+        'Some second bit of additional advice.',
+        'Some third bit of additional advice.',
+      ],
+      questions: {
+        'some-question-id': {},
+      },
+      submitText: 'some-submit-text',
+    };
+
+    const sectionData = {
+      data: {},
+    };
+
+    it('should return the context when the manifest and data from the api is provided', async () => {
+      const expectedContext = {
+        title: 'Some section title',
+        submitActionUrl: '/solution/some-solution-id/section/some-section-id',
+        mainAdvice: 'Some main advice.',
+        additionalAdvice: [
+          'Some first bit of additional advice.',
+          'Some second bit of additional advice.',
+          'Some third bit of additional advice.',
+        ],
+        questions: [
+          {
+            id: 'some-question-id',
+          },
+        ],
+        returnToDashboardUrl: '/solution/some-solution-id',
+        submitText: 'some-submit-text',
+      };
+
+      ManifestProvider.prototype.getSectionManifest.mockReturnValue(sectionManifest);
+      ApiProvider.prototype.getSectionData.mockResolvedValue(sectionData);
+
+      const context = await getSectionPageContext({ solutionId: 'some-solution-id' });
+
+      expect(context).toEqual(expectedContext);
+    });
+
+    it('should throw an error when no data is returned from the ApiProvider', async () => {
+      ManifestProvider.prototype.getSubDashboardManifest.mockReturnValue(sectionManifest);
+      ApiProvider.prototype.getSubDashboardData.mockResolvedValue({});
+
+      try {
+        await getSectionPageContext({ solutionId: 'some-solution-id' });
+      } catch (err) {
+        expect(err).toEqual(new Error('No data returned'));
+      }
+    });
+  });
+});

--- a/app/pages/section/controller.test.js
+++ b/app/pages/section/controller.test.js
@@ -1,4 +1,4 @@
-import { getSectionPageContext } from './controller';
+import { getSectionPageContext, getSectionPageErrorContext } from './controller';
 import { ManifestProvider } from '../../manifestProvider';
 import { ApiProvider } from '../../apiProvider';
 
@@ -6,26 +6,27 @@ jest.mock('../../manifestProvider');
 jest.mock('../../apiProvider');
 
 describe('section controller', () => {
+  const sectionManifest = {
+    id: 'some-section-id',
+    title: 'Some section title',
+    mainAdvice: 'Some main advice.',
+    additionalAdvice: [
+      'Some first bit of additional advice.',
+      'Some second bit of additional advice.',
+      'Some third bit of additional advice.',
+    ],
+    questions: {
+      'some-question-id': {},
+    },
+    submitText: 'some-submit-text',
+  };
+
+  const sectionData = {
+    data: {},
+  };
+
+
   describe('getSectionPageContext', () => {
-    const sectionManifest = {
-      id: 'some-section-id',
-      title: 'Some section title',
-      mainAdvice: 'Some main advice.',
-      additionalAdvice: [
-        'Some first bit of additional advice.',
-        'Some second bit of additional advice.',
-        'Some third bit of additional advice.',
-      ],
-      questions: {
-        'some-question-id': {},
-      },
-      submitText: 'some-submit-text',
-    };
-
-    const sectionData = {
-      data: {},
-    };
-
     it('should return the context when the manifest and data from the api is provided', async () => {
       const expectedContext = {
         title: 'Some section title',
@@ -62,6 +63,35 @@ describe('section controller', () => {
       } catch (err) {
         expect(err).toEqual(new Error('No data returned'));
       }
+    });
+  });
+
+  describe('getSectionPageErrorContext', () => {
+    it('should return the context when the manifest is provided', async () => {
+      const expectedContext = {
+        title: 'Some section title',
+        submitActionUrl: '/solution/some-solution-id/section/some-section-id',
+        mainAdvice: 'Some main advice.',
+        additionalAdvice: [
+          'Some first bit of additional advice.',
+          'Some second bit of additional advice.',
+          'Some third bit of additional advice.',
+        ],
+        questions: [
+          {
+            id: 'some-question-id',
+          },
+        ],
+        returnToDashboardUrl: '/solution/some-solution-id',
+        submitText: 'some-submit-text',
+      };
+
+      ManifestProvider.prototype.getSectionManifest.mockReturnValue(sectionManifest);
+      ApiProvider.prototype.getSectionData.mockResolvedValue(sectionData);
+
+      const context = await getSectionPageErrorContext({ solutionId: 'some-solution-id' });
+
+      expect(context).toEqual(expectedContext);
     });
   });
 });


### PR DESCRIPTION
All Api calls are now made via the ApiProvider. 

Also added unit tests for the controller.

Need to consider how we handle unsuccessful retrievals of the manifests from the ManifestProvider.