### PR TITLE
changed default config for documentHost to 8090

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -12,7 +12,7 @@ module.exports = {
   apiHost: process.env.API_HOST || 'http://localhost:8080',
 
   // DOCUMENT_HOST
-  documentHost: process.env.DOCUMENT_HOST || 'http://localhost:8081',
+  documentHost: process.env.DOCUMENT_HOST || 'http://localhost:8090',
 
   // LOGGER_LEVEL options are info, warn, error, off
   loggerLevel: process.env.LOGGER_LEVEL || 'error',


### PR DESCRIPTION
People on Windows have some McAfee thing running on 8081
I'd like the port numbers to match between marketing pages and DAPI to make it easier to start it all up locally